### PR TITLE
设置 menuGroup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ file-download
 .idea/
 
 local.properties
+/wix311/

--- a/desktop/build.gradle.kts
+++ b/desktop/build.gradle.kts
@@ -36,6 +36,7 @@ compose.desktop {
                 iconFile.set(project.file("ic_acfun.icns"))
             }
             windows {
+                menuGroup = "AcFun"
                 iconFile.set(project.file("ic_acfun.ico"))
             }
             linux {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,8 @@
 kotlin.code.style=official
 android.useAndroidX=true
-kotlin.version=1.7.10
+kotlin.version=1.8.0
 agp.version=7.2.2
-compose.version=1.2.0
+compose.version=1.3.0
 
 android.injected.testOnly=false
 org.gradle.daemon=true


### PR DESCRIPTION
1. 设置了 menuGroup ，安装msi后，快捷方式会出现在菜单组中。
![image](https://user-images.githubusercontent.com/16540656/219558918-915ca1c8-e318-4910-8bd0-921e74fc4516.png)

2. 升级compose-jb 的版本到 1.3.0，因为 compose-jb 1.3 以前的版本有一个严重的bug: https://github.com/JetBrains/compose-jb/issues/1969
